### PR TITLE
Specify host 0.0.0.0 such that this service can properly run on Kubernetes

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,4 +78,4 @@ if __name__ == "__main__":
     else:
         # run flask app with HTTP endpoint
         print("Running on port", PORT, "on path", PATH)
-        app.run(port=PORT)
+        app.run(host='0.0.0.0', port=PORT)


### PR DESCRIPTION
# This PR

- Adds host=0.0.0.0 to the `app.run` command such that the service can be accessed from other Kubernetes services

# Related Issues

Fixes #8 

