### PR TITLE
Set thread to be a daemon, wait for thread to end

### DIFF
--- a/keptn.py
+++ b/keptn.py
@@ -352,7 +352,7 @@ def start_polling(keptn_api_endpoint, keptn_api_token):
     KEPTN_API_EVENT_ENDPOINT = "/v1/event"
     
     print("Starting to poll...")
-    x = threading.Thread(target=StandaloneKeptn.poll)
+    x = threading.Thread(target=StandaloneKeptn.poll, daemon=True)
     x.start()
 
     return x

--- a/main.py
+++ b/main.py
@@ -68,9 +68,9 @@ if __name__ == "__main__":
         print("Exit using CTRL-C")
 
         # wait til exit (e.g., using CTRL C)
-        while True:
+        while thread.is_alive():
             try:
-                time.sleep(0.5)
+                thread.join(0.5)
             except KeyboardInterrupt:
                 print("Exiting...")
                 sys.exit(0)


### PR DESCRIPTION
# This PR

- Ensures that the polling thread ends properly when the user decides to use CTRL C

# Related Issues

- Fixes #4 
